### PR TITLE
Add timeout and Cloud SQL Proxy exit check to deploy scripts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -27,12 +27,34 @@ gcloud app deploy --quiet
 # Start the Cloud SQL Proxy, writing logs to a log file.
 cloud-sql-proxy -dir /cloudsql > log/cloudsql.log 2>&1 &
 
-# Read the Cloud SQL Proxy log file until a line containing "Ready for new
-# connections" is found. Then, continue to the next line.
-(tail -f log/cloudsql.log &) | sed '/Ready for new connections/q'
+# Set cloud_sql_proxy_pid to the PID of the last command, i.e. running
+# cloud-sql-proxy.
+cloud_sql_proxy_pid=$!
 
-# Migrate the production database. Set the DB_ADMIN environment variable to
-# indicate that the command should connect to the database using a user that
-# has sufficient privileges to migrate the database:
-# http://jldbasa.github.io/blog/2014/02/14/mysql-user-minimum-required-privileges-for-rails/
-DB_ADMIN=true RAILS_ENV=production rake db:migrate
+# Time out after 10 seconds.
+for (( i = 0; i < 10; i++ )); do
+
+  # If the Cloud SQL Proxy log file contains 'Ready for new connections', the
+  # Cloud SQL Proxy is ready to access the production database.
+  if cat log/cloudsql.log | grep -q 'Ready for new connections'; then
+
+    echo "Ready to connect to the production database."
+
+    # Migrate the production database. Set the DB_ADMIN environment variable to
+    # indicate that the command should connect to the database using a user that
+    # has sufficient privileges to migrate the database:
+    # http://jldbasa.github.io/blog/2014/02/14/mysql-user-minimum-required-privileges-for-rails/
+    DB_ADMIN=true RAILS_ENV=production rake db:migrate
+
+    exit 0
+
+  fi
+
+  sleep 1
+
+done
+
+echo "Cloud SQL Proxy didn't connect to the production database within 10 seconds. Timing out..."
+
+# If the Cloud SQL Proxy exited, indicate that there is an error.
+exit 1

--- a/test-deploy.sh
+++ b/test-deploy.sh
@@ -26,18 +26,36 @@ bundle exec rake assets:precompile RAILS_ENV=production
 # Start the Cloud SQL Proxy, writing logs to a log file.
 cloud-sql-proxy -dir /cloudsql > log/cloudsql.log 2>&1 &
 
-# Read the Cloud SQL Proxy log file until a line containing "Ready for new
-# connections" is found. Then, continue to the next line.
-(tail -f log/cloudsql.log &) | sed '/Ready for new connections/q'
+# Set cloud_sql_proxy_pid to the PID of the last command, i.e. running
+# cloud-sql-proxy.
+cloud_sql_proxy_pid = $!
 
-# Try to connect to the production database.
-RAILS_ENV=production rake db:version
+# Loop while the Cloud SQL Proxy is still running.
+while kill -0 $cloud_sql_proxy_pid; do
 
-# Set the DB_ADMIN environment variable to indicate that the command should
-# connect to the database using a user that has sufficient privileges to migrate
-# the database:
-# http://jldbasa.github.io/blog/2014/02/14/mysql-user-minimum-required-privileges-for-rails/
-DB_ADMIN=true RAILS_ENV=production rake db:version
+  # If the Cloud SQL Proxy log file contains 'Ready for new connections', the
+  # Cloud SQL Proxy is ready to access the production database.
+  if cat log/cloudsql.log | grep -q 'Ready for new connections'; then
 
-# Perform a dry run of the pending migrations against the production database.
-DB_ADMIN=true RAILS_ENV=production rake db:migrate --dry-run
+    # Try to connect to the production database.
+    RAILS_ENV=production rake db:version
+
+    # Set the DB_ADMIN environment variable to indicate that the command should
+    # connect to the database using a user that has sufficient privileges to migrate
+    # the database:
+    # http://jldbasa.github.io/blog/2014/02/14/mysql-user-minimum-required-privileges-for-rails/
+    DB_ADMIN=true RAILS_ENV=production rake db:version
+
+    # Perform a dry run of the pending migrations against the production database.
+    DB_ADMIN=true RAILS_ENV=production rake db:migrate --dry-run
+
+    exit 0
+
+  fi
+
+  sleep 1
+
+done
+
+# If the Cloud SQL Proxy exited, indicate that there is an error.
+exit 1

--- a/test-deploy.sh
+++ b/test-deploy.sh
@@ -28,7 +28,7 @@ cloud-sql-proxy -dir /cloudsql > log/cloudsql.log 2>&1 &
 
 # Set cloud_sql_proxy_pid to the PID of the last command, i.e. running
 # cloud-sql-proxy.
-cloud_sql_proxy_pid = $!
+cloud_sql_proxy_pid=$!
 
 # Loop while the Cloud SQL Proxy is still running.
 while kill -0 $cloud_sql_proxy_pid; do

--- a/test-deploy.sh
+++ b/test-deploy.sh
@@ -37,7 +37,7 @@ for (( i = 0; i < 10; i++ )); do
   # Cloud SQL Proxy is ready to access the production database.
   if cat log/cloudsql.log | grep -q 'Ready for new connections'; then
 
-    echo "Connected to the production database."
+    echo "Ready to connect to the production database."
 
     # Try to connect to the production database.
     RAILS_ENV=production rake db:version

--- a/test-deploy.sh
+++ b/test-deploy.sh
@@ -35,7 +35,7 @@ for (( i = 0; i < 10; i++ )); do
 
   # If the Cloud SQL Proxy log file contains 'Ready for new connections', the
   # Cloud SQL Proxy is ready to access the production database.
-  if cat log/cloudsql.log | grep -q 'Ready for new connections'; then
+  if cat log/cloudsql.log | grep -q 'Ready for new connections oh hi Mark'; then
 
     # Try to connect to the production database.
     RAILS_ENV=production rake db:version

--- a/test-deploy.sh
+++ b/test-deploy.sh
@@ -30,8 +30,8 @@ cloud-sql-proxy -dir /cloudsql > log/cloudsql.log 2>&1 &
 # cloud-sql-proxy.
 cloud_sql_proxy_pid=$!
 
-# Loop while the Cloud SQL Proxy is still running.
-while kill -0 $cloud_sql_proxy_pid; do
+# Time out after 10 seconds.
+for (( i = 0; i < 10; i++ )); do
 
   # If the Cloud SQL Proxy log file contains 'Ready for new connections', the
   # Cloud SQL Proxy is ready to access the production database.

--- a/test-deploy.sh
+++ b/test-deploy.sh
@@ -37,6 +37,8 @@ for (( i = 0; i < 10; i++ )); do
   # Cloud SQL Proxy is ready to access the production database.
   if cat log/cloudsql.log | grep -q 'Ready for new connections'; then
 
+    echo "Connected to the production database."
+
     # Try to connect to the production database.
     RAILS_ENV=production rake db:version
 
@@ -56,6 +58,8 @@ for (( i = 0; i < 10; i++ )); do
   sleep 1
 
 done
+
+echo "Cloud SQL Proxy didn't connect to the production database within 10 seconds. Timing out..."
 
 # If the Cloud SQL Proxy exited, indicate that there is an error.
 exit 1

--- a/test-deploy.sh
+++ b/test-deploy.sh
@@ -35,7 +35,7 @@ for (( i = 0; i < 10; i++ )); do
 
   # If the Cloud SQL Proxy log file contains 'Ready for new connections', the
   # Cloud SQL Proxy is ready to access the production database.
-  if cat log/cloudsql.log | grep -q 'Ready for new connections oh hi Mark'; then
+  if cat log/cloudsql.log | grep -q 'Ready for new connections'; then
 
     # Try to connect to the production database.
     RAILS_ENV=production rake db:version


### PR DESCRIPTION
With this change, if the Cloud SQL Proxy takes more than 10 seconds to connect to the production database, or exits without connecting, the test deploy and deploy scripts will fail.